### PR TITLE
fix: Phase 3 security headers and Disqus cleanup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,6 @@ pagination.pagerSize : 5
 title: Matt Lincoln - Salesforce, Pardot and Martech.
 
 # Change it to your Disqus shortname before using
-disqusShortname: hugo-theme-stack
 
 # Theme i18n support
 # Available values: en, fr, id, ja, ko, pt-br, zh-cn

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,10 @@
   for = "/ts/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Proposed Changes
- Appended standard HTTP security headers to netlify.toml.
- Purged legacy Disqus shortname from config.yaml to prevent unused scripts loading.